### PR TITLE
ical の URL を手動で設定できるようにすることを目指すところ

### DIFF
--- a/TitechAppLite/View/ContentView.swift
+++ b/TitechAppLite/View/ContentView.swift
@@ -22,6 +22,14 @@ struct ContentView: View {
                     .listRowInsets(EdgeInsets())
                 }
             }
+            .toolbar {
+                ToolbarItem {
+                    Button(action: {
+                    }) {
+                        Text("設定")
+                    }
+                }
+            }
             .navigationBarTitle(Text("スケジュール"), displayMode: .inline)
             
         }


### PR DESCRIPTION
## 概要

スケジュール画面の右上にURLの設定ボタンをつけたい

### 見た目

とりあえずボタンだけ（遷移不可）
![Simulator Screen Shot - iPod touch (7th generation) - 2020-10-04 at 17 19 28](https://user-images.githubusercontent.com/63225562/95010631-cb777800-0665-11eb-8106-f744eb48d866.png)
